### PR TITLE
Add lock logic to avoid multiple instances running

### DIFF
--- a/src/AppDelegate.swift
+++ b/src/AppDelegate.swift
@@ -1,6 +1,7 @@
 import Cocoa
 
 final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
+	private var singletonLock: SingletonLock
 	private let hotKeyManager = HotKeyManager()
 	private let menuBuilder = MenuBuilder()
 	private weak var currentApp: NSRunningApplication?
@@ -10,18 +11,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 	private static let kAXPressAction = "AXPress" as CFString
 	private static let appActivationDelay: TimeInterval = 0.1
 
-	// Lock file properties
-	private static let uniqueLockFileName = "menuanywhere.lock"
-	private var lockFileHandle: FileHandle?
-	private var lockFilePath: URL?
+	init(singletonLock: SingletonLock) {
+		self.singletonLock = singletonLock
+		super.init()
+	}
 
 	func applicationDidFinishLaunching(_: Notification) {
-		if !acquireSingleInstanceLock() {
-			print("Exiting this instance...")
-			NSApp.terminate(nil)
-			return
-		}
-
 		hotKeyManager.onActivated = { [weak self] in
 			self?.showMenu(at: NSEvent.mouseLocation)
 		}
@@ -32,76 +27,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 	func applicationWillTerminate(_: Notification) {
 		hotKeyManager.cleanup()
 		cleanupActiveMenu()
-		releaseSingleInstanceLock()
 	}
-
-	private func acquireSingleInstanceLock() -> Bool {
-		let temporaryDirectory = FileManager.default.temporaryDirectory
-
-		lockFilePath = temporaryDirectory.appendingPathComponent(Self.uniqueLockFileName)
-
-		guard let path = lockFilePath else {
-			print("Error: Failed to construct lock file path.")
-			return false
-		}
-
-		do {
-			// Attempt to open/create the lock file for updating.
-			// If the file doesn't exist, this will create it.
-            if !FileManager.default.fileExists(atPath: path.path) {
-				FileManager.default.createFile(atPath: path.path, contents: nil, attributes: nil)
-			}
-			lockFileHandle = try FileHandle(forUpdating: path)
-			guard let fileDescriptor = lockFileHandle?.fileDescriptor else {
-                print("Error: Could not get file descriptor for lock file.")
-                return false
-            }
-
-			// Attempt to acquire an exclusive, non-blocking lock.
-			let result = flock(fileDescriptor, LOCK_EX | LOCK_NB)
-
-			if result == 0 {
-				return true
-			} else if errno == EWOULDBLOCK {
-				print("Error: Another instance is running (lock file is held).")
-				lockFileHandle?.closeFile()
-				lockFileHandle = nil
-				return false
-			} else {
-				print("Error: Failed to acquire lock file: \(String(cString: strerror(errno)))")
-				lockFileHandle?.closeFile()
-				lockFileHandle = nil
-
-				try? FileManager.default.removeItem(at: lockFilePath!)
-				return false
-			}
-		} catch {
-			print("Error: Lock file operation failed: \(error.localizedDescription)")
-			lockFileHandle?.closeFile()
-			lockFileHandle = nil
-
-			try? FileManager.default.removeItem(at: lockFilePath!)
-			return false
-		}
-	}
-
-	private func releaseSingleInstanceLock() {
-		if let handle = lockFileHandle {
-			flock(handle.fileDescriptor, LOCK_UN)
-			handle.closeFile()
-			lockFileHandle = nil
-			if let path = lockFilePath {
-				do {
-					try FileManager.default.removeItem(at: path)
-					print("Released and removed single instance lock from /tmp.")
-				} catch {
-					print("Failed to remove lock file from /tmp: \(error.localizedDescription)")
-				}
-			}
-		}
-	}
-
-	// MARK: - Existing Menu Logic (Unchanged)
 
 	private func showMenu(at location: NSPoint) {
 		cleanupActiveMenu()
@@ -115,7 +41,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
 		guard
 			AXUIElementCopyAttributeValue(appElement, Self.kAXMenuBarAttributeString, &menuBar)
-			== .success,
+				== .success,
 			let menuBarElement = menuBar,
 			CFGetTypeID(menuBarElement as CFTypeRef) == AXUIElementGetTypeID()
 		else {
@@ -165,8 +91,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
 	@objc private func menuAction(_ sender: NSMenuItem) {
 		guard let obj = sender.representedObject,
-		      CFGetTypeID(obj as CFTypeRef) == AXUIElementGetTypeID(),
-		      let app = currentApp, !app.isTerminated
+			CFGetTypeID(obj as CFTypeRef) == AXUIElementGetTypeID(),
+			let app = currentApp, !app.isTerminated
 		else { return }
 
 		let element = obj as! AXUIElement

--- a/src/AppDelegate.swift
+++ b/src/AppDelegate.swift
@@ -10,7 +10,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 	private static let kAXPressAction = "AXPress" as CFString
 	private static let appActivationDelay: TimeInterval = 0.1
 
+	// Lock file properties
+	private static let uniqueLockFileName = "menuanywhere.lock"
+	private var lockFileHandle: FileHandle?
+	private var lockFilePath: URL?
+
 	func applicationDidFinishLaunching(_: Notification) {
+		if !acquireSingleInstanceLock() {
+			print("Exiting this instance...")
+			NSApp.terminate(nil)
+			return
+		}
+
 		hotKeyManager.onActivated = { [weak self] in
 			self?.showMenu(at: NSEvent.mouseLocation)
 		}
@@ -21,7 +32,76 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 	func applicationWillTerminate(_: Notification) {
 		hotKeyManager.cleanup()
 		cleanupActiveMenu()
+		releaseSingleInstanceLock()
 	}
+
+	private func acquireSingleInstanceLock() -> Bool {
+		let temporaryDirectory = FileManager.default.temporaryDirectory
+
+		lockFilePath = temporaryDirectory.appendingPathComponent(Self.uniqueLockFileName)
+
+		guard let path = lockFilePath else {
+			print("Error: Failed to construct lock file path.")
+			return false
+		}
+
+		do {
+			// Attempt to open/create the lock file for updating.
+			// If the file doesn't exist, this will create it.
+            if !FileManager.default.fileExists(atPath: path.path) {
+				FileManager.default.createFile(atPath: path.path, contents: nil, attributes: nil)
+			}
+			lockFileHandle = try FileHandle(forUpdating: path)
+			guard let fileDescriptor = lockFileHandle?.fileDescriptor else {
+                print("Error: Could not get file descriptor for lock file.")
+                return false
+            }
+
+			// Attempt to acquire an exclusive, non-blocking lock.
+			let result = flock(fileDescriptor, LOCK_EX | LOCK_NB)
+
+			if result == 0 {
+				return true
+			} else if errno == EWOULDBLOCK {
+				print("Error: Another instance is running (lock file is held).")
+				lockFileHandle?.closeFile()
+				lockFileHandle = nil
+				return false
+			} else {
+				print("Error: Failed to acquire lock file: \(String(cString: strerror(errno)))")
+				lockFileHandle?.closeFile()
+				lockFileHandle = nil
+
+				try? FileManager.default.removeItem(at: lockFilePath!)
+				return false
+			}
+		} catch {
+			print("Error: Lock file operation failed: \(error.localizedDescription)")
+			lockFileHandle?.closeFile()
+			lockFileHandle = nil
+
+			try? FileManager.default.removeItem(at: lockFilePath!)
+			return false
+		}
+	}
+
+	private func releaseSingleInstanceLock() {
+		if let handle = lockFileHandle {
+			flock(handle.fileDescriptor, LOCK_UN)
+			handle.closeFile()
+			lockFileHandle = nil
+			if let path = lockFilePath {
+				do {
+					try FileManager.default.removeItem(at: path)
+					print("Released and removed single instance lock from /tmp.")
+				} catch {
+					print("Failed to remove lock file from /tmp: \(error.localizedDescription)")
+				}
+			}
+		}
+	}
+
+	// MARK: - Existing Menu Logic (Unchanged)
 
 	private func showMenu(at location: NSPoint) {
 		cleanupActiveMenu()
@@ -35,7 +115,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
 		guard
 			AXUIElementCopyAttributeValue(appElement, Self.kAXMenuBarAttributeString, &menuBar)
-				== .success,
+			== .success,
 			let menuBarElement = menuBar,
 			CFGetTypeID(menuBarElement as CFTypeRef) == AXUIElementGetTypeID()
 		else {
@@ -85,8 +165,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
 	@objc private func menuAction(_ sender: NSMenuItem) {
 		guard let obj = sender.representedObject,
-			CFGetTypeID(obj as CFTypeRef) == AXUIElementGetTypeID(),
-			let app = currentApp, !app.isTerminated
+		      CFGetTypeID(obj as CFTypeRef) == AXUIElementGetTypeID(),
+		      let app = currentApp, !app.isTerminated
 		else { return }
 
 		let element = obj as! AXUIElement

--- a/src/HotKeyManager.swift
+++ b/src/HotKeyManager.swift
@@ -1,7 +1,7 @@
 import Carbon
 
 class HotKeyManager {
-	static let signature: OSType = 0x4D62_6172  // "Mbar"
+	static let signature: OSType = 0x4D62_6172 // "Mbar"
 	private static let hotKeyID = EventHotKeyID(signature: signature, id: 1)
 	private static let eventType = EventTypeSpec(
 		eventClass: OSType(kEventClassKeyboard),
@@ -23,8 +23,8 @@ class HotKeyManager {
 			return false
 		}
 
-		self.keyCode = code
-		self.modifiers = config.modifiers.compactMap { KeyMappings.modifiers[$0.lowercased()] }
+		keyCode = code
+		modifiers = config.modifiers.compactMap { KeyMappings.modifiers[$0.lowercased()] }
 			.reduce(0, |)
 
 		guard registerHotKey(), setupEventHandler() else {

--- a/src/MenuBuilder.swift
+++ b/src/MenuBuilder.swift
@@ -5,10 +5,9 @@ class MenuBuilder {
 		NSFont.menuFont(ofSize: NSFont.systemFontSize), toHaveTrait: .boldFontMask
 	)
 
-	func buildMenu(from element: AXUIElement, target: AnyObject?, action: Selector?) -> [NSMenuItem]
-	{
+	func buildMenu(from element: AXUIElement, target: AnyObject?, action: Selector?) -> [NSMenuItem] {
 		return autoreleasepool {
-			return buildMenuItems(from: element, target: target, action: action, isSubmenu: false)
+			buildMenuItems(from: element, target: target, action: action, isSubmenu: false)
 		}
 	}
 
@@ -66,7 +65,7 @@ class MenuBuilder {
 
 					let isApple =
 						item.title == "Apple"
-						|| (itemsData[index]["AXRoleDescription"] as? String) == "Apple menu"
+							|| (itemsData[index]["AXRoleDescription"] as? String) == "Apple menu"
 
 					if isApple {
 						appleItem = item
@@ -78,7 +77,7 @@ class MenuBuilder {
 		}
 
 		if let apple = appleItem {
-			if !items.isEmpty && items.last?.isSeparatorItem == false {
+			if !items.isEmpty, items.last?.isSeparatorItem == false {
 				items.append(.separator())
 			}
 			items.append(apple)
@@ -123,7 +122,7 @@ class MenuBuilder {
 		let isApple =
 			item.title == "Apple" || (itemData["AXRoleDescription"] as? String) == "Apple menu"
 
-		if !isSubmenu && (isFirst || isApple) {
+		if !isSubmenu, isFirst || isApple {
 			item.attributedTitle = NSAttributedString(
 				string: item.title,
 				attributes: [.font: boldFont]
@@ -160,17 +159,18 @@ class MenuBuilder {
 		action: Selector?
 	) -> Bool {
 		guard let subChildren = values["AXChildren"] as? [AXUIElement],
-			!subChildren.isEmpty,
-			let firstSub = subChildren.first,
-			let subRole = firstSub.getAttribute("AXRole") as? String,
-			subRole == "AXMenu"
+		      !subChildren.isEmpty,
+		      let firstSub = subChildren.first,
+		      let subRole = firstSub.getAttribute("AXRole") as? String,
+		      subRole == "AXMenu"
 		else {
 			return false
 		}
 
 		let submenu = NSMenu(title: item.title)
 		let submenuItems = buildMenuItems(
-			from: firstSub, target: target, action: action, isSubmenu: true)
+			from: firstSub, target: target, action: action, isSubmenu: true
+		)
 		submenuItems.forEach { submenu.addItem($0) }
 		item.submenu = submenu
 		return true
@@ -190,7 +190,7 @@ extension AXUIElement {
 		return autoreleasepool {
 			var value: AnyObject?
 			guard AXUIElementCopyAttributeValue(self, "AXChildren" as CFString, &value) == .success,
-				let children = value as? [AXUIElement], !children.isEmpty
+			      let children = value as? [AXUIElement], !children.isEmpty
 			else {
 				return nil
 			}
@@ -205,13 +205,13 @@ extension AXUIElement {
 			let options = AXCopyMultipleAttributeOptions(rawValue: 0)
 
 			guard AXUIElementCopyMultipleAttributeValues(self, attrs, options, &values) == .success,
-				let results = values as? [Any], results.count == names.count
+			      let results = values as? [Any], results.count == names.count
 			else { return nil }
 
 			var dict: [String: Any] = [:]
 			dict.reserveCapacity(names.count)
 
-			for i in 0..<names.count {
+			for i in 0 ..< names.count {
 				let value = results[i]
 				if !(value is NSNull) {
 					dict[names[i]] = value

--- a/src/SingletonLock.swift
+++ b/src/SingletonLock.swift
@@ -1,0 +1,35 @@
+import AppKit
+
+final actor SingletonLock {
+	enum Error: Swift.Error {
+		case instanceAlreadyRunning
+		case lockFileError(String)
+	}
+
+	private let lockFilePath = NSTemporaryDirectory().appending("com.acsandmann.menuanywhere.lock")
+	private var lockFileDescriptor: CInt
+
+	init() throws {
+		let fd = open(lockFilePath, O_CREAT | O_RDWR, 0o644)
+		if fd == -1 {
+			throw Error.lockFileError(String(cString: strerror(errno)))
+		}
+
+		if flock(fd, LOCK_EX | LOCK_NB) == -1 {
+			close(fd)
+			guard errno == EWOULDBLOCK else {
+				throw Error.lockFileError(
+					"Failed to acquire lock: \(String(cString: strerror(errno)))")
+			}
+			throw Error.instanceAlreadyRunning
+		}
+
+		lockFileDescriptor = fd
+	}
+
+	deinit {
+		flock(lockFileDescriptor, LOCK_UN)
+		close(lockFileDescriptor)
+		try? FileManager.default.removeItem(atPath: lockFilePath)
+	}
+}

--- a/src/main.swift
+++ b/src/main.swift
@@ -1,16 +1,28 @@
 import Cocoa
 
-AccessibilityManager.ensurePermissions()
+do {
+	let singletonLock = try SingletonLock()
 
-let delegate = AppDelegate()
-NSApplication.shared.delegate = delegate
+	AccessibilityManager.ensurePermissions()
 
-NotificationCenter.default.addObserver(
-	delegate,
-	selector: #selector(delegate.menuDidEndTracking(_:)),
-	name: NSMenu.didEndTrackingNotification,
-	object: nil
-)
+	let delegate = AppDelegate(singletonLock: singletonLock)
+	NSApplication.shared.delegate = delegate
 
-print("Starting menuanywhere...")
-let _ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)
+	NotificationCenter.default.addObserver(
+		delegate,
+		selector: #selector(delegate.menuDidEndTracking(_:)),
+		name: NSMenu.didEndTrackingNotification,
+		object: nil
+	)
+
+	print("Starting menuanywhere...")
+	_ = NSApplicationMain(CommandLine.argc, CommandLine.unsafeArgv)
+} catch SingletonLock.Error.instanceAlreadyRunning {
+	print(
+		"menuwhere is already running. please close the existing instance before starting a new one."
+	)
+	exit(0)
+} catch {
+	print("An error occurred on startup: \(error.localizedDescription)")
+	exit(1)
+}


### PR DESCRIPTION
# Use case

I use [aerospace](https://github.com/nikitabobko/AeroSpace) as my WM and I'd like to automatically start `menuanywhere` when I start aerospace.

With the current version of `menuanywhere`, each time I restart aerospace, another instance of the app is created.

# Solution

Create a lock logic to avoid multiple instances to run at the same time. This is implemented in this PR.